### PR TITLE
Use an absolute path to load the db file

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var _ = require('lodash');
 
 var Datastore = require('nedb'),
-	db = new Datastore({ filename: './data/xkcd', autoload: true });
+	db = new Datastore({ filename: __dirname + '/data/xkcd', autoload: true });
 
 
 module.exports = function (words, callback) {


### PR DESCRIPTION
This makes it so that the module can also be used in other node projects even when xkcd-cli is contained within the `node_modules` of the depending package. When another package required xkcd-cli, the relative path referred to by `'./data/xkcd'` started at the root of the requiring package, rather than xkcd-cli itself, causing it to create an empty db, rather than load the one it already had.
