### PR TITLE
Update dependencies

### DIFF
--- a/crawl/index.js
+++ b/crawl/index.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var argv = require('minimist')(process.argv.slice(2));
 var jsdom = require('jsdom');
 var ProgressBar = require('progress');
+var jquery = fs.readFileSync("./node_modules/jquery/dist/jquery.min.js", "utf-8");
 
 var relPath = './';
 
@@ -50,7 +51,7 @@ function parse (i, job, errors, window) {
 		setTimeout(fetch.bind(null, i, job), getRandomSec());
 		return;
 	}
-	
+
 	var $ = window.$;
 
 	var elements = $('#Transcript').parent().nextAll('dl');
@@ -101,11 +102,11 @@ function start (job) {
 }
 
 function fetch (i, job) {
-	jsdom.env(
-		"http://www.explainxkcd.com/wiki/index.php/" + i,
-		["http://code.jquery.com/jquery.js"],
-		parse.bind(null, i, job)
-	);
+	jsdom.env({
+		url: "http://www.explainxkcd.com/wiki/index.php/" + i,
+		src: [jquery],
+		done: parse.bind(null, i, job)
+	});
 }
 
 fs.readFile(dataFile, function (err, file) {
@@ -117,6 +118,11 @@ fs.readFile(dataFile, function (err, file) {
 		from: data.latest,
 		to: argv.to,
 		registry: []
+	}
+
+	if (!argv.to) {
+		console.log('Error: "to" parameter is mandantory');
+		return;
 	}
 
 	start(job);

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "CLI tool for xkcd to find the most relevant to a context search  $ xkcd [keywords]",
   "main": "index.js",
   "dependencies": {
-    "jsdom": "^3.1.2",
-    "lodash": "^3.9.3",
-    "minimist": "^1.1.1",
-    "nedb": "^1.1.2"
+    "lodash": "^4.6.1",
+    "minimist": "^1.2.0",
+    "nedb": "^1.8.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-release": "^0.12.0",
-    "jsdom": "^5.4.3",
+    "grunt-release": "^0.13.0",
+    "jquery": "^2.2.2",
+    "jsdom": "^8.1.0",
     "progress": "^1.1.8"
   },
   "scripts": {


### PR DESCRIPTION
- set latest jsdom to skip contextify install (fix for Windows platform)
- add jquery npm dependency to direct file loading and increasing crawler speed
- update npm dependencies to latest version
